### PR TITLE
fixed win-wad-agent.json instance parramter

### DIFF
--- a/win-wad-agent.json
+++ b/win-wad-agent.json
@@ -99,7 +99,7 @@
       "sku": {
         "name": "Standard_A2",
         "tier": "Standard",
-        "capacity": 2
+        "capacity": "[parameters('instanceCount')]"
       },
       "properties": {
         "upgradePolicy": {


### PR DESCRIPTION
The parameter instanceCount was not being used in win-wad-agent.json, it was hard coded to 2
